### PR TITLE
Added the wiki_wymbol shield factory

### DIFF
--- a/wmt_db/config/cycling.py
+++ b/wmt_db/config/cycling.py
@@ -31,6 +31,7 @@ ROUTES.symbols = (filters.tags_all('.color_box',
                                    {'operator' : 'Norwich City Council',}),
                   '.swiss_mobile',
                   '.jel_symbol',
+                  '.wiki_symbol',
                   '.ref_color_symbol',
                   '.ref_symbol',
                   '.color_box')

--- a/wmt_db/config/hiking.py
+++ b/wmt_db/config/hiking.py
@@ -98,6 +98,7 @@ ROUTES.network_map = {
         }
 ROUTES.tag_filter = filter_route_tags
 ROUTES.symbols = ('.image_symbol',
+                  '.wiki_symbol',
                   '.swiss_mobile',
                   '.jel_symbol',
                   '.kct_symbol',

--- a/wmt_db/config/mtb.py
+++ b/wmt_db/config/mtb.py
@@ -28,8 +28,10 @@ ROUTES.network_map = {
         }
 ROUTES.symbols = ('.swiss_mobile',
                   '.jel_symbol',
+                  '.wiki_symbol',
                   '.ref_color_symbol',
                   '.ref_symbol',
+                  '.osmc_symbol',
                   '.color_box')
 ROUTES.symbol_datadir = SYMBOL_DIR / 'mtb'
 

--- a/wmt_db/config/riding.py
+++ b/wmt_db/config/riding.py
@@ -33,6 +33,7 @@ ROUTES.network_map = {
         'lcn': Network.LOC(0),
         }
 ROUTES.symbols = ('.osmc_symbol',
+                  '.wiki_symbol',
                   '.ref_symbol',
                   '.color_box')
 ROUTES.symbol_datadir = SYMBOL_DIR / 'riding'


### PR DESCRIPTION
This pull request works with the one already submitted on waymarkedtrails-shields. It adds support for SVG files defined in tag wiki:symbol when rendering route shields.