### PR TITLE
Prefer osmc:symbol for KČT bicycle routes

### DIFF
--- a/wmt_db/config/cycling.py
+++ b/wmt_db/config/cycling.py
@@ -29,6 +29,8 @@ ROUTES.network_map = {
         }
 ROUTES.symbols = (filters.tags_all('.color_box',
                                    {'operator' : 'Norwich City Council',}),
+                  filters.tags_all('.osmc_symbol',
+                                   {'operator' : 'cz:KČT',}),
                   '.swiss_mobile',
                   '.jel_symbol',
                   '.ref_color_symbol',


### PR DESCRIPTION
Most of the Czech (KČT) bicycle network is marked with ref, however there is a minority of bike routes that do have ref but are actually waymarked with symbols based on the system used for hiking, but larger and with yellow background instead of white.

I suggest adding a localized rendering rule for KČT bicycle routes that do have osmc:symbol specified to be shown that symbol instead of the plain ref. I've included this change in this PR.

The tags used for hiking ([`kct_red`](https://wiki.openstreetmap.org/wiki/Key:kct_red) etc.) are also used on bicycle routes with value `bicycle`, however they do not provide the granularity that is in place for hiking - e.g. no `bicycle`-`local` or `bicycle`-`peak` combinations that exist in the wild, hence my suggestion to use osmc:symbol instead.

Thank you for considering!

Some examples from the wild (click to enlarge):
[![](https://osm.fit.vutbr.cz/fody/files/250px/42265.jpg)](https://osm.fit.vutbr.cz/fody/files/42265.jpg) [![](https://osm.fit.vutbr.cz/fody/files/250px/42269.jpg)](https://osm.fit.vutbr.cz/fody/files/42269.jpg) [![](https://osm.fit.vutbr.cz/fody/files/250px/23834.jpg)](https://osm.fit.vutbr.cz/fody/files/23834.jpg) [![](https://osm.fit.vutbr.cz/fody/files/250px/33844.jpg)](https://osm.fit.vutbr.cz/fody/files/33844.jpg)

