### PR TITLE
wmt-makedb: Replace os.execvp with subprocess.run for better flow control

### DIFF
--- a/wmt-makedb
+++ b/wmt-makedb
@@ -12,6 +12,7 @@ from textwrap import dedent
 import os
 import sys
 import shutil
+import subprocess
 import logging
 import importlib
 import sqlalchemy as sa
@@ -54,9 +55,8 @@ class BaseDb:
             args.extend(('-U', self.options.ro_user))
 
         print('osgende-import', args)
-        os.execvp('osgende-import', args)
-
-        return 1
+        result = subprocess.run(args)
+        return result.returncode
 
     def update(self):
         if not self._is_base_map_update_needed():
@@ -67,9 +67,8 @@ class BaseDb:
         args.extend(('-S', str(options.diff_size * 1024)))
 
         print('osgende-import', args)
-        os.execvp('osgende-import', args)
-
-        return 1
+        result = subprocess.run(args)
+        return result.returncode
 
     def _is_base_map_update_needed(self):
         status = StatusManager(sa.MetaData())


### PR DESCRIPTION
## `wmt-makedb`: Replace `os.execvp` with `subprocess.run` for better flow control

Replaced `os.execvp()` with `subprocess.run()` when calling `osgende-import`.

`os.execvp()` replaces the current process, which prevents any subsequent
code from executing and makes it difficult for callers to manage the
lifecycle of the `wmt-makedb` utility.

Benefits:
- Allows `wmt-makedb` to continue execution after the import step.
- Ensures correct propagation of return codes to the calling shell.
- Improves compatibility with orchestration tools and automation scripts.
- Enables sequential execution of tasks in environments like Docker.
